### PR TITLE
go-1436: ignore server host check in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "start": "webpack-dev-server --mode=development --output-public-path=dist --watch",
     "start-docker": "webpack-dev-server --mode=production --output-public-path=dist --host=0.0.0.0"
   },
+  "devServer": {
+    "compress": true,
+    "host": "0.0.0.0",
+    "disableHostCheck": true
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/phenotips/open-pedigree.git"


### PR DESCRIPTION
Ignore the host check provided by webpack-dev-server in package.json
as this prevents us from deploying the application.