### PR TITLE
go-1436: disable host check when running from script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack -p",
     "start": "webpack-dev-server --mode=development --output-public-path=dist --watch",
-    "start-docker": "webpack-dev-server --mode=production --output-public-path=dist --host=0.0.0.0"
+    "start-docker": "webpack-dev-server --mode=production --disable-host-check --output-public-path=dist --host=0.0.0.0"
   },
   "devServer": {
     "compress": true,


### PR DESCRIPTION
Add `--disable-host-check` flag to the `start-docker` script.