### PR TITLE
go-1436: explictly export docker env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,13 @@ FROM node:14
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
+# set environmental variables
+RUN export AUTH_0_DOMAIN_URL=${AUTH_0_DOMAIN_URL} && \
+    export AUTH_0_CLIENT_ID=${AUTH_0_CLIENT_ID} && \
+    export AUTH_0_AUDIENCE=${AUTH_0_AUDIENCE} && \
+    export REACT_APP_URL=${REACT_APP_URL} && \
+    export HASURA_URL=${HASURA_URL}
+
 # install any dependencies
 # we copy package*.json over to make use of docker's cached builds
 COPY package*.json .
@@ -14,5 +21,5 @@ RUN npm install \
 COPY . .
 
 # run the application and make it available outside the container
-CMD ["npm", "run", "start-docker"]
+ENTRYPOINT ["npm", "run", "start-docker"]
 EXPOSE 9000


### PR DESCRIPTION
Explictly export environmental variables in Docker image as they don't
seem to be available at execution time.  Change `cmd` to `entrypoint`
command in Dockerfile.