### PR TITLE
go-1756: update gql to fetch whole family record

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -68,9 +68,9 @@ document.observe('dom:loaded', async function () {
         if (urlParams.has('phenopacket_id')) {
           const query = `
             query GetOpenPedigreeData($phenopacketId: uuid!) {
-              openPedigreeData: open_pedigree_data(where: {phenopacket_id: {_eq: $phenopacketId}}) {
+              family(where: {phenopacket_id: {_eq: $phenopacketId}}) {
                 id
-                rawData: raw_data
+                rawData: raw_open_pedigree_data
               }
             }
           `;
@@ -83,7 +83,7 @@ document.observe('dom:loaded', async function () {
           });
 
           return onSuccess(
-            result?.data?.openPedigreeData[0]?.rawData?.jsonData ?? null
+            result?.data?.family[0]?.rawData?.jsonData ?? null
           );
         } else {
           console.warn('No phenopacket ID has been specified. No data will be saved.')


### PR DESCRIPTION
Update the `GetOpenPedigreeData` GraphQL query to fetch the entire
family record, rather than just the `open_pedigree_data` fields.  This
will allow us to extend the functionality to retrieve patient
demographics and other details on the related cohort.