### PR TITLE
go-1777: fixed pedigree import, enhanced HPO selector.

### DIFF
--- a/src/script/hpoTerm.js
+++ b/src/script/hpoTerm.js
@@ -58,6 +58,18 @@ var HPOTerm = Class.create( {
   },
 
   load: function(callWhenReady) {
+    var _this = this;
+    jQuery.ajax({
+      url: 'https://hpo.jax.org/api/hpo/term/' + encodeURIComponent(HPOTerm.desanitizeID(this._hpoID)),
+      type: 'GET',
+      async: true,
+      error: _this.onDataError.bind(_this),
+      success: _this.onDataReady.bind(_this),
+      complete: callWhenReady ? callWhenReady : {},
+    });
+
+    /*
+    // Code of the original Open Pedigree HPO term class.
     var baseServiceURL = HPOTerm.getServiceURL();
     var queryURL       = baseServiceURL + '&q=id%3A' + HPOTerm.desanitizeID(this._hpoID).replace(':','%5C%3A');
     //console.log("QueryURL: " + queryURL);
@@ -67,9 +79,26 @@ var HPOTerm = Class.create( {
       //onComplete: complete.bind(this)
       onComplete: callWhenReady ? callWhenReady : {}
     });
+    */
+  },
+
+  onDataError : function(response) {
+    console.log('onDataError', response);
+    var err = response.responseJSON;
+    this._name = err.message;
+    console.log('ORPHANET API ERROR: error = ' + err.error + ', message = ' + err.message);
   },
 
   onDataReady : function(response) {
+    console.log('onDataReady', response);
+    try {
+      this._name = response.details.name;
+      console.log('LOADED HPO TERM: id = ' + HPOTerm.desanitizeID(this._hpoID) + ', name = ' + this._name);
+    } catch (err) {
+      console.log('[LOAD HPO TERM] Error: ' +  err);
+    }
+    /*
+    // Code of the original Open Pedigree HPO term class.
     try {
       var parsed = JSON.parse(response.responseText);
       //console.log(JSON.stringify(parsed));
@@ -78,6 +107,7 @@ var HPOTerm = Class.create( {
     } catch (err) {
       console.log('[LOAD HPO TERM] Error: ' +  err);
     }
+    */
   }
 });
 
@@ -104,11 +134,13 @@ HPOTerm.isValidID = function(id) {
   return pattern.test(id);
 };
 
+/*
+// Code of the original Open Pedigree HPO term class.
 HPOTerm.getServiceURL = function() {
   //return new XWiki.Document('SolrService', 'PhenoTips').getURL('get') + '?';
   // This suggestion from the link doues not work, 
   // but some valid link is needed to input HPO terms as free text.
   return 'https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.obo?'
 };
-
+*/
 export default HPOTerm;

--- a/src/script/view/nodeMenu.js
+++ b/src/script/view/nodeMenu.js
@@ -224,21 +224,23 @@ var NodeMenu = Class.create({
               return div;
             },
           },
-          load: function(query, callback) {
-            if (!query.length) return callback();
+          onInitialize: function() {
+            var _this = this
             jQuery.ajax({
-              // Note that "max" url parameter sets the number of suggestions retireved form the HPO API (lower = less laggy).
-              url: 'https://hpo.jax.org/api/hpo/search/?q=' + encodeURIComponent(query) + '&max=25&offset=0&category=terms',
+              url: 'https://hpo.jax.org/api/hpo/search/?q=HP%3A&max=-1&offset=0&category=terms',
               type: 'GET',
+              async: false,
               error: function() {
-                callback();
+                console.log('ERROR: Failed to obtain HPO terms from hpo.jax.org/api.');
+                return;
               },
               success: function(res) {
                 res.terms.each(function(item){
                   var hpoTerm = new HPOTerm(item.id, item.name);
                   item.value = hpoTerm.getDisplayName();
-                })
-                callback(res.terms);
+                  _this.addOption(item);
+                });
+                _this.refreshOptions();
               }
             });
           },
@@ -246,7 +248,6 @@ var NodeMenu = Class.create({
             this.fieldName = 'hpo_positive';
             document.fire('custom:selectize:changed', this);
           },
-          
         });
         
         /*


### PR DESCRIPTION
Previously, the pedigree import functionality did not load HPO terms since no HPO API calls were made in hpoTerm class. Now fixed. Previously, HPO API calls were made on each user input and consequently the selector control was quite laggy. Now all HPO terms are loaded when control is initialized.