### PR TITLE
go-1742: replaced gene selector control.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -28,12 +28,24 @@ document.observe('dom:loaded',function() {
 
 document.observe('pedigree:person:set:hpo', function(event) {
   // Function to print Person external ID and HPO terms when the latter are updated.
-  console.log('Person HPO Terms were updated!')
-  console.log('Person external ID:', event.memo.node.getExternalID())
-  console.log('HPO Terms:')
-  var hpos = event.memo.value
+  console.log('Person HPO Terms were updated!');
+  console.log('Person external ID:', event.memo.node.getExternalID());
+  console.log('HPO Terms:');
+  var hpos = event.memo.value;
   for(var i = 0; i < hpos.length; i++) {
-    var hpo = hpos[i]
+    var hpo = hpos[i];
     console.log(`${i}) ID: ${HPOTerm.desanitizeID(hpo.getID())}, Name: ${hpo.getName()}`);
+  }
+});
+
+document.observe('pedigree:person:set:genes', function(event) {
+  // Function to print Person external ID and genes when the latter are updated.
+  console.log('Person genes were updated!');
+  console.log('Person external ID:', event.memo.node.getExternalID());
+  console.log('Genes:');
+  var genes = event.memo.value;
+  for(var i = 0; i < genes.length; i++) {
+    var gene = genes[i];
+    console.log(`${i}) ID: ${gene.getID()}, Name: ${gene.getSymbol()}`);
   }
 });

--- a/src/script/gene.js
+++ b/src/script/gene.js
@@ -1,0 +1,54 @@
+/*
+ * Gene is a class for storing gene information and from HGNC database.
+ * These genes can be attributed to an individual in the Pedigree.
+ *
+ * @param hgncID the id number for the gene, taken from the HGNC database
+ * @param symbol a string representing the symbol of the gene (sometimes also called name)
+ */
+
+var Gene = Class.create( {
+
+  initialize: function(hgncID, symbol, group) {
+    // Load HGNC ID and symbol from the display name.
+    if (hgncID == null && symbol.includes(' | ')) {
+      var geneInfo = symbol.split(' | ');
+      this._hgncID = geneInfo[0];
+      this._symbol = geneInfo[1];
+    } else {
+      this._hgncID = hgncID ? hgncID : '-';
+      this._symbol = symbol;
+    }
+    this._group = group ? group : '';
+  },
+
+  /*
+     * Returns the HGNC ID of the gene
+     */
+  getID: function() {
+    return this._hgncID;
+  },
+
+  /*
+     * Returns the symbol of the gene
+     */
+  getSymbol: function() {
+    //return this._hgncID;
+    return this._symbol;
+  },
+
+  /*
+    * Returns the group of the gene
+    */
+  getGroup: function() {
+    return this._group;
+  },
+
+  /*
+     * Returns the display name of a gene in format "HGNC ID | symbol"
+     */
+  getDisplayName: function() {
+    return this._hgncID + ' | ' + this._symbol;
+  },
+});
+
+export default Gene;

--- a/src/style/editor.css
+++ b/src/style/editor.css
@@ -636,6 +636,28 @@
 }
 
 /* ===========================================
+ * NODE MENU GENES TERM SELECTIZE.JS
+ */
+
+.selectize-control.suggest-genes .selectize-dropdown > div {
+  border-bottom: 1px solid rgba(0,0,0,0.05);
+}
+
+.selectize-control.suggest-genes .selectize-dropdown .id {
+  font-weight: bold;
+  margin-left: 5px;
+}
+
+.selectize-control.suggest-genes .selectize-dropdown .gene {
+  width: 95px;
+  display: inline-block;
+}
+
+.selectize-control.suggest-genes .selectize-dropdown .italic {
+  font-style: italic;
+}
+
+/* ===========================================
  * NODE TYPE OPTIONS
  */
 


### PR DESCRIPTION
New control is implemented using selectize.js, and obtains gene data from HGNC FTP on load. There is also an option to manually add custom gene names (i.e. without HGNC IDs).