### PR TITLE
go-1961: Added option to switch node coloring.

### DIFF
--- a/public/vendor/font-awesome/scss/_icons.scss
+++ b/public/vendor/font-awesome/scss/_icons.scss
@@ -787,3 +787,4 @@
 .#{$fa-css-prefix}-superpowers:before { content: $fa-var-superpowers; }
 .#{$fa-css-prefix}-wpexplorer:before { content: $fa-var-wpexplorer; }
 .#{$fa-css-prefix}-meetup:before { content: $fa-var-meetup; }
+.#{$fa-css-prefix}-palette:before { content: $fa-var-palette; }

--- a/public/vendor/font-awesome/scss/_variables.scss
+++ b/public/vendor/font-awesome/scss/_variables.scss
@@ -797,4 +797,4 @@ $fa-var-yoast: "\f2b1";
 $fa-var-youtube: "\f167";
 $fa-var-youtube-play: "\f16a";
 $fa-var-youtube-square: "\f166";
-
+$fa-var-palette: "\f53f";

--- a/src/script/controller.js
+++ b/src/script/controller.js
@@ -1,5 +1,8 @@
 import { cloneObject, Timer } from 'pedigree/model/helpers';
 import PedigreeEditorParameters from 'pedigree/pedigreeEditorParameters';
+import HPOTerm from 'pedigree/hpoTerm';
+import Disorder from 'pedigree/disorder';
+import Gene from 'pedigree/gene';
 
 /**
  * ...
@@ -25,6 +28,79 @@ var Controller = Class.create({
     document.observe('pedigree:person:newsibling',         this.handlePersonNewSibling);
     document.observe('pedigree:person:newpartnerandchild', this.handlePersonNewPartnerAndChild);
     document.observe('pedigree:partnership:newchild',      this.handleRelationshipNewChild);
+    document.observe('pedigree:graph:switch-coloring',     this.handleSwitchColoring);
+  },
+  
+  handleSwitchColoring: function(event) {
+    // Options: 'Disorder', 'Gene', 'HPO'
+    editor.switchColoringSource();
+    if (editor.getColoringSource() == 'Disorder') {
+      editor.getDisorderLegend().setShowColors(true);
+      editor.getGeneLegend().setShowColors(false);
+      editor.getHPOLegend().setShowColors(false);
+    } else if (editor.getColoringSource() == 'Gene') {
+      editor.getDisorderLegend().setShowColors(false);
+      editor.getGeneLegend().setShowColors(true);
+      editor.getHPOLegend().setShowColors(false);
+    } else if (editor.getColoringSource() == 'HPO') {
+      editor.getDisorderLegend().setShowColors(false);
+      editor.getGeneLegend().setShowColors(false);
+      editor.getHPOLegend().setShowColors(true);
+    }
+
+    // Refresh all nodes
+
+    // Disorders
+    var nodes = editor.getDisorderLegend().getAllNodeObjects();
+    var nodeDisorders = {}
+    for (const [nodeID, disorderDataList] of Object.entries(nodes)) {
+      var node = editor.getView().getNode(nodeID);
+      nodeDisorders[nodeID] = []
+      disorderDataList.each(function(v) {
+        // v is [id, name] array
+        nodeDisorders[nodeID].push(new Disorder(v[0], v[1]));
+        node.removeDisorder(v[0]);
+      });
+    }
+    for (const [nodeID, disorders] of Object.entries(nodeDisorders)) {
+      var node = editor.getView().getNode(nodeID);
+      node.setDisorders(disorders);
+    }
+
+    // Genes
+    var nodes = editor.getGeneLegend().getAllNodeObjects();
+    var nodeGenes = {}
+    for (const [nodeID, geneDataList] of Object.entries(nodes)) {
+      var node = editor.getView().getNode(nodeID);
+      nodeGenes[nodeID] = []
+      geneDataList.each(function(v) {
+        // v is [id, name] array
+        var gene = new Gene(editor.getGeneLegend().getHGNCID(v[1]), v[1]);
+        nodeGenes[nodeID].push(gene);
+        node.removeGene(gene);
+      });
+    }
+    for (const [nodeID, genes] of Object.entries(nodeGenes)) {
+      var node = editor.getView().getNode(nodeID);
+      node.setGenes(genes);
+    }
+
+    // HPOs
+    var nodes = editor.getHPOLegend().getAllNodeObjects();
+    var nodeHPOs = {}
+    for (const [nodeID, hpoDataList] of Object.entries(nodes)) {
+      var node = editor.getView().getNode(nodeID);
+      nodeHPOs[nodeID] = []
+      hpoDataList.each(function(v) {
+        // v is [id, name] array
+        nodeHPOs[nodeID].push(new HPOTerm(v[0], v[1]));
+        node.removeHPO(v[0]);
+      });
+    }
+    for (const [nodeID, hpos] of Object.entries(nodeHPOs)) {
+      var node = editor.getView().getNode(nodeID);
+      node.setHPO(hpos);
+    }
   },
 
   handleUndo: function(event) {

--- a/src/script/pedigree.js
+++ b/src/script/pedigree.js
@@ -54,6 +54,10 @@ var PedigreeEditor = Class.create({
 
     window.editor = this;
 
+    // initialize node coloring sources and selected source
+    this.coloringSources = ['Disorder', 'Gene', 'HPO']
+    this.coloringSource = 'Disorder'
+
     // initialize main data structure which holds the graph structure
     this._graphModel = DynamicPositionedGraph.makeEmpty(PedigreeEditorParameters.attributes.layoutRelativePersonWidth, PedigreeEditorParameters.attributes.layoutRelativeOtherWidth);
 
@@ -65,6 +69,7 @@ var PedigreeEditor = Class.create({
     this._nodetypeSelectionBubble = new NodetypeSelectionBubble(false);
     this._siblingSelectionBubble  = new NodetypeSelectionBubble(true);
     this._disorderLegend = new DisorderLegend();
+    this._disorderLegend.setShowColors(true);
     this._geneLegend = new GeneLegend();
     this._hpoLegend = new HPOLegend();
     this._fhirTerminologyHelper = options.fhirTerminologyHelper || new DefaultFhirTerminologyHelper();
@@ -130,6 +135,12 @@ var PedigreeEditor = Class.create({
       }
     });
 
+    var switchColorButton = $('action-switch-coloring');
+    switchColorButton && this.updateSwitchColorButtonLabel();
+    switchColorButton && switchColorButton.on('click', function(event) {
+      document.fire('pedigree:graph:switch-coloring');
+    });
+
     var unsupportedBrowserButton = $('action-readonlymessage');
     unsupportedBrowserButton && unsupportedBrowserButton.on('click', function(event) {
       alert('Your browser does not support all the features required for ' +
@@ -161,6 +172,38 @@ var PedigreeEditor = Class.create({
     return () => {
       editor.getSaveLoadEngine().save(patientDataUrl);
     };
+  },
+
+  /**
+     * Return coloring source Disorder, Gene, or HPO.
+     * @method getColoringSource
+     * @return {String} coloring source 
+     */
+  getColoringSource() {
+    return this.coloringSource;
+  },
+
+  /**
+     * Switch selected coloring source between Disorder, Gene, and HPO.
+     * @method switchColoringSource
+     */
+  switchColoringSource: function() {
+    var i = this.coloringSources.indexOf(this.coloringSource);
+    if (i < this.coloringSources.length - 1) {
+      this.coloringSource = this.coloringSources[i + 1];
+    } else {
+      this.coloringSource = this.coloringSources[0];
+    }
+    this.updateSwitchColorButtonLabel();
+  },
+
+  /**
+     * Updates the label of switch coloring button with the current coloring source (Disorder, Gene, HPO).
+     * @method updateSwitchColorButtonLabel
+     */
+  updateSwitchColorButtonLabel: function() {
+    var switchColorButton = $('action-switch-coloring');
+    switchColorButton.children[1].innerText = `Switch coloring (Now ${this.coloringSource})`;
   },
 
   /**

--- a/src/script/view/disorderLegend.js
+++ b/src/script/view/disorderLegend.js
@@ -87,7 +87,7 @@ var DisorgerLegend = Class.create( Legend, {
      * @return {HTMLLIElement} List element to be insert in the legend
      */
   _generateElement: function($super, disorderID, name) {
-    if (!this._objectColors.hasOwnProperty(disorderID)) {
+    if (!this._objectColors.hasOwnProperty(disorderID) && this._showColors) {
       var color = this._generateColor(disorderID);
       this._objectColors[disorderID] = color;
       document.fire('disorder:color', {'id' : disorderID, color: color});
@@ -127,15 +127,18 @@ var DisorgerLegend = Class.create( Legend, {
       // [red/yellow]           prefColors = ["#FEE090", '#f8ebb7', '#eac080', '#bf6632', '#9a4500', '#a47841', '#c95555', '#ae6c57'];
       // [original yellow/blue] prefColors = ["#FEE090", '#E0F8F8', '#8ebbd6', '#4575B4', '#fca860', '#9a4500', '#81a270'];
       // [green]                prefColors = ['#81a270', '#c4e8c4', '#56a270', '#b3b16f', '#4a775a', '#65caa3'];
-      prefColors = ['#E0F8F8', '#92c0db', '#4575B4', '#949ab8', '#FEE090', '#bf6632', '#fca860', '#9a4500', '#d12943', '#00a2bf'];
+      // prefColors = ['#E0F8F8', '#92c0db', '#4575B4', '#949ab8', '#FEE090', '#bf6632', '#fca860', '#9a4500', '#d12943', '#00a2bf'];
+      // Viridis (12) color palette https://waldyrious.net/viridis-palette-generator/
+      prefColors = ['#fde725', '#c2df23', '#86d549', '#52c569', '#2ab07f', '#1e9b8a', '#25858e', '#2d708e', '#38588c', '#433e85', '#482173', '#440154'];
     usedColors.each( function(color) {
       prefColors = prefColors.without(color);
     });
     if (disorderID == 'affected') {
-      if (usedColors.indexOf('#FEE090') > -1 ) {
+      // Original default color was #FEE090
+      if (usedColors.indexOf('#fde725') > -1 ) {
         return '#dbad71';
       } else {
-        return '#FEE090';
+        return '#fde725';
       }
     }
     if(prefColors.length > 0) {

--- a/src/script/view/geneLegend.js
+++ b/src/script/view/geneLegend.js
@@ -1,6 +1,7 @@
 import Raphael from 'pedigree/raphael';
 import Legend from 'pedigree/view/legend';
 import Person from 'pedigree/view/person';
+import Gene from 'pedigree/gene';
 
 /**
  * Class responsible for keeping track of candidate genes.
@@ -13,12 +14,37 @@ var GeneLegend = Class.create( Legend, {
 
   initialize: function($super) {
     $super('Candidate Genes');
+    // Save gene HGNC IDs. They are displayed in node menu, but not in the legend itself.
+    // Used when legend is refreshed during coloring switch
+    this._hgncIDs = {}
   },
 
   _getPrefix: function(id) {
     return 'gene';
   },
 
+  /**
+   * Save gene HGNC ID
+   *
+   * @method addHGNCID
+   * @param {String} name Gene Symbol
+   * @param {String} hgncID Gene HGNC ID
+   */
+  addHGNCID: function(name, hgncID) {
+    this._hgncIDs[name] = hgncID;
+  },
+
+  /**
+   * Get gene HGNC ID
+   *
+   * @method getHGNCID
+   * @param {String} name Gene Symbol
+   * @return {String} Gene HGNC ID
+   */
+  getHGNCID: function(name) {
+    return this._hgncIDs[name];
+  },
+  
   /**
      * Generate the element that will display information about the given disorder in the legend
      *
@@ -28,7 +54,7 @@ var GeneLegend = Class.create( Legend, {
      * @return {HTMLLIElement} List element to be insert in the legend
      */
   _generateElement: function($super, geneID, name) {
-    if (!this._objectColors.hasOwnProperty(geneID)) {
+    if (!this._objectColors.hasOwnProperty(geneID) && this._showColors) {
       var color = this._generateColor(geneID);
       this._objectColors[geneID] = color;
       document.fire('gene:color', {'id' : geneID, color: color});
@@ -52,7 +78,9 @@ var GeneLegend = Class.create( Legend, {
 
     var usedColors = Object.values(this._objectColors),
       // green palette
-      prefColors = ['#81a270', '#c4e8c4', '#56a270', '#b3b16f', '#4a775a', '#65caa3'];
+      // prefColors = ['#81a270', '#c4e8c4', '#56a270', '#b3b16f', '#4a775a', '#65caa3'];
+      // Inferno (12) color palette https://waldyrious.net/viridis-palette-generator/
+      prefColors = ['#fcffa4', '#f5db4c', '#fcae12', '#f78410', '#e65d2f', '#cb4149', '#a92e5e', '#85216b', '#5f136e', '#390963', '#140b34', '#000004'];
     usedColors.each( function(color) {
       prefColors = prefColors.without(color);
     });

--- a/src/script/view/hpoLegend.js
+++ b/src/script/view/hpoLegend.js
@@ -1,4 +1,5 @@
 import HPOTerm from 'pedigree/hpoTerm';
+import Raphael from 'pedigree/raphael';
 import Legend from 'pedigree/view/legend';
 
 /**
@@ -40,17 +41,6 @@ var HPOLegend = Class.create( Legend, {
   },
 
   /**
-     * Retrieve the color associated with the given object
-     *
-     * @method getObjectColor
-     * @param {String|Number} id ID of the object
-     * @return {String} CSS color value for that disorder
-     */
-  getObjectColor: function(id) {
-    return '#CCCCCC';
-  },
-
-  /**
      * Registers an occurrence of a phenotype.
      *
      * @method addCase
@@ -74,9 +64,58 @@ var HPOLegend = Class.create( Legend, {
      * @private
      */
   _updateTermName: function(id) {
-    //console.log("updating phenotype display for " + id + ", name = " + this.getTerm(id).getName());
     var name = this._legendBox.down('li#' + this._getPrefix() + '-' + id + ' .disorder-name');
     name.update(this.getTerm(id).getName());
+  },
+
+  /**
+     * Generate the element that will display information about the given hpo in the legend
+     *
+     * @method _generateElement
+     * @param {String} id The id for the hpo term
+     * @param {String} name The human-readable gene description
+     * @return {HTMLLIElement} List element to be insert in the legend
+     */
+   _generateElement: function($super, id, name) {
+    if (!this._objectColors.hasOwnProperty(id) && this._showColors) {
+      var color = this._generateColor(id);
+      this._objectColors[id] = color;
+      document.fire('hpo:color', {'id' : id, color: color});
+    }
+
+    return $super(id, name);
+  },
+
+  /**
+     * Generates a CSS color.
+     * Has preference for some predefined colors that can be distinguished in gray-scale
+     *
+     * @method generateColor
+     * @return {String} CSS color
+     */
+  _generateColor: function(id) {
+    if(this._objectColors.hasOwnProperty(id)) {
+      return this._objectColors[id];
+    }
+
+    var usedColors = Object.values(this._objectColors),
+      // RColorBrewer "Paired" palette
+      //prefColors = ["#A6CEE3", "#1F78B4", "#B2DF8A", "#33A02C", "#FB9A99", "#E31A1C", 
+      //  "#FDBF6F", "#FF7F00", "#CAB2D6", "#6A3D9A", "#FFFF99", "#B15928"];
+      // Magma (12) color palette https://waldyrious.net/viridis-palette-generator/
+      prefColors = ['#fcfdbf', '#fed395', '#fea973', '#fa7d5e', '#e95462', '#c83e73', '#a3307e', '#7e2482', '#59157e', '#331067', '#120d31', '#000004'];
+    usedColors.each( function(color) {
+      prefColors = prefColors.without(color);
+    });
+    if(prefColors.length > 0) {
+      return prefColors[0];
+    } else {
+      var randomColor = Raphael.getColor();
+      while(randomColor == '#ffffff' || usedColors.indexOf(randomColor) != -1) {
+        randomColor = '#'+((1<<24)*Math.random()|0).toString(16);
+      }
+      return randomColor;
+    }
   }
 });
 

--- a/src/script/view/legend.js
+++ b/src/script/view/legend.js
@@ -10,9 +10,11 @@ import Helpers from 'pedigree/model/helpers';
 var Legend = Class.create( {
 
   initialize: function(title) {
+    this._showColors = false;      // if true legend and nodes are coloured.
     this._affectedNodes  = {};     // for each object: the list of affected person nodes
 
     this._objectColors = {};       // for each object: the corresponding object color
+    this._objectNames = {}; 
 
     var legendContainer = $('legend-container');
     if (legendContainer == undefined) {
@@ -52,6 +54,26 @@ var Legend = Class.create( {
   },
 
   /**
+     * Set legend coloring status.
+     *
+     * @method setShowColors
+     * @param {Boolean} legend coloring status
+     */
+  setShowColors: function(value) {
+    this._showColors = value;
+  },
+
+  /**
+     * Returns legend coloring status.
+     *
+     * @method getShowColors
+     * @return {Boolean} legend coloring status
+     */
+  getShowColors: function() {
+    return this._showColors;
+  },
+
+  /**
      * Retrieve the color associated with the given object
      *
      * @method getObjectColor
@@ -59,8 +81,8 @@ var Legend = Class.create( {
      * @return {String} CSS color value for the object, displayed on affected nodes in the pedigree and in the legend
      */
   getObjectColor: function(id) {
-    if (!this._objectColors.hasOwnProperty(id)) {
-      return '#ff0000';
+    if (!this._objectColors.hasOwnProperty(id) || !this._showColors) {
+      return '#CCCCCC';
     }
     return this._objectColors[id];
   },
@@ -89,6 +111,7 @@ var Legend = Class.create( {
       this._legendBox.show();
     }
     if(!this._hasAffectedNodes(id)) {
+      this._objectNames[id] = name;
       this._affectedNodes[id] = [nodeID];
       var listElement = this._generateElement(id, name);
       this._list.insert(listElement);
@@ -111,6 +134,7 @@ var Legend = Class.create( {
       if(this._affectedNodes[id].length == 0) {
         delete this._affectedNodes[id];
         delete this._objectColors[id];
+        delete this._objectNames[id];
         var htmlElement = this._getListElementForObjectWithID(id);
         htmlElement.remove();
         if(Object.keys(this._affectedNodes).length == 0) {
@@ -120,6 +144,26 @@ var Legend = Class.create( {
         this._updateCaseNumbersForObject(id);
       }
     }
+  },
+
+  /**
+     * Return a dictionary where keys are Node IDs, and values are arreys of legend object [id, name] tuples.
+     *
+     * @method getAllNodeObjects
+     * @return {Object} dictionary of all node objects
+     */
+  getAllNodeObjects: function() {
+    var nodes = {};
+    for (const [id, name] of Object.entries(this._objectNames)) {
+      this._affectedNodes[id].forEach(function (nodeID) {
+        if (nodeID in nodes) {
+          nodes[nodeID].push([id, name]);
+        } else {
+          nodes[nodeID] = [[id, name]];
+        }
+      });
+    }
+    return nodes;
   },
 
   _getListElementForObjectWithID: function(id) {

--- a/src/script/view/nodeMenu.js
+++ b/src/script/view/nodeMenu.js
@@ -474,6 +474,24 @@ var NodeMenu = Class.create({
       _this._updateDisorderColor(event.memo.id, event.memo.color);
     });
 
+    // Update hpo colors
+    this._updateHPOColor = function(id, color) {
+      this.menuBox.select('.field-hpo_positive li input[value="' + id + '"]').each(function(item) {
+        var colorBubble = item.up('li').down('.disorder-color');
+        if (!colorBubble) {
+          colorBubble = new Element('span', {'class' : 'disorder-color'});
+          item.up('li').insert({top : colorBubble});
+        }
+        colorBubble.setStyle({background : color});
+      });
+    }.bind(this);
+    document.observe('hpo:color', function(event) {
+      if (!event.memo || !event.memo.id || !event.memo.color) {
+        return;
+      }
+      _this._updateHPOColor(event.memo.id, event.memo.color);
+    });
+
     // Update gene colors
     this._updateGeneColor = function(id, color) {
       this.menuBox.select('.field-candidate_genes li input[value="' + id + '"]').each(function(item) {
@@ -1047,7 +1065,9 @@ var NodeMenu = Class.create({
             var disorder = new Disorder(v.id, v.value);
             target.selectize.addOption({value: disorder.getDisplayName(), id: disorder.getDesanitizedDisorderID(), name: disorder.getName()});
             target.selectize.addItem(disorder.getDisplayName(), true);
-            _this._updateDisorderColor(v.id, editor.getDisorderLegend().getObjectColor(v.id));
+            if (editor.getDisorderLegend().getShowColors()) {
+              _this._updateDisorderColor(v.id, editor.getDisorderLegend().getObjectColor(v.id));
+            }
           });
         }
       }
@@ -1078,6 +1098,9 @@ var NodeMenu = Class.create({
             var hpoTerm = new HPOTerm(v.id, v.value);
             target.selectize.addOption({value: hpoTerm.getDisplayName(), id: hpoTerm.getDesanitizedID(), name: hpoTerm.getName()});
             target.selectize.addItem(hpoTerm.getDisplayName(), true);
+            if (editor.getHPOLegend().getShowColors()) {
+              _this._updateHPOColor(v.id, editor.getHPOLegend().getObjectColor(v.id));
+            }
           });
         }
       }
@@ -1109,7 +1132,9 @@ var NodeMenu = Class.create({
             // but only symbols are used in gene legend.
             target.selectize.addOption({value: gene.getDisplayName(), id: gene.getID(), name: gene.getSymbol(), group: gene.getGroup()});
             target.selectize.addItem(gene.getDisplayName(), true);
-            _this._updateGeneColor(gene.getSymbol(), editor.getGeneLegend().getObjectColor(gene.getSymbol()));
+            if (editor.getGeneLegend().getShowColors()) {
+              _this._updateGeneColor(gene.getSymbol(), editor.getGeneLegend().getObjectColor(gene.getSymbol()));
+            }
           });
         }
       }

--- a/src/script/view/person.js
+++ b/src/script/view/person.js
@@ -590,14 +590,24 @@ var Person = Class.create(AbstractPerson, {
      * @return {Array of Strings}
      */
   getAllNodeColors: function() {
+    // Result contains colors only from the colored legends (getShowColors = true).
     var result = [];
-    for (var i = 0; i < this.getDisorders().length; i++) {
-      result.push(editor.getDisorderLegend().getObjectColor(this.getDisorders()[i]));
+    if (editor.getHPOLegend().getShowColors()) {
+      for (var i = 0; i < this.getHPO().length; i++) {
+        result.push(editor.getHPOLegend().getObjectColor(this.getHPO()[i]));
+      }
+    }
+    if (editor.getDisorderLegend().getShowColors()) {
+      for (var i = 0; i < this.getDisorders().length; i++) {
+        result.push(editor.getDisorderLegend().getObjectColor(this.getDisorders()[i]));
+      }
     }
     // Candidate genes are stored in "{ID} | {Symbol}" (e.g. DisplayName) in person object, 
     // but only symbols are used in gene legend.
-    for (var i = 0; i < this.getGeneSymbols().length; i++) {
-      result.push(editor.getGeneLegend().getObjectColor(this.getGeneSymbols()[i]));
+    if (editor.getGeneLegend().getShowColors()) {
+      for (var i = 0; i < this.getGeneSymbols().length; i++) {
+        result.push(editor.getGeneLegend().getObjectColor(this.getGeneSymbols()[i]));
+      }
     }
     return result;
   },
@@ -754,6 +764,7 @@ var Person = Class.create(AbstractPerson, {
     for(var i = 0; i < hpos.length; i++) {
       this.addHPO( hpos[i] );
     }
+    this.getGraphics().updateDisorderShapes();
   },
 
   /**
@@ -777,6 +788,7 @@ var Person = Class.create(AbstractPerson, {
       // Candidate genes are stored in "{ID} | {Symbol}" (e.g. DisplayName) in person object, 
       // but only symbols are used in gene legend.
       editor.getGeneLegend().addCase(gene.getSymbol(), gene.getSymbol(), this.getID());
+      editor.getGeneLegend().addHGNCID(gene.getSymbol(), gene.getID());
       this.getGenes().push(gene.getDisplayName());
     }
   },

--- a/src/script/view/workspace.js
+++ b/src/script/view/workspace.js
@@ -184,6 +184,11 @@ var Workspace = Class.create({
           { key : 'clear',  label : 'Clear all', icon : 'times-circle'}
         ]
       }, {
+        name : 'visual',
+        items: [
+          { key : 'switch-coloring',  label : 'Switch coloring', icon : 'palette'}
+        ]
+      }, {
         name : 'output',
         items: [
           { key : 'export',    label : 'Export', icon : 'file-export'},
@@ -199,7 +204,9 @@ var Workspace = Class.create({
       });
     };
     var _createMenuItem = function(data) {
-      var mi = new Element('span', {'id' : 'action-' + data.key, 'class' : 'menu-item ' + data.key}).insert(new Element('span', {'class' : 'fa fa-' + data.icon})).insert(' ').insert(data.label);
+      var mLabel = new Element('span');
+      mLabel.textContent = data.label;
+      var mi = new Element('span', {'id' : 'action-' + data.key, 'class' : 'menu-item ' + data.key}).insert(new Element('span', {'class' : 'fa fa-' + data.icon})).insert(' ').insert(mLabel);
       if (data.callback && typeof(this[data.callback]) == 'function') {
         mi.observe('click', function() {
           this[data.callback]();


### PR DESCRIPTION
Previosly, pedigree nodes were coloured based on associated disorders and genes. Now the coloring mode can be switched between disorders, genes, and HPOs, using 'Switch coloring' button in the top control menu.