### PR TITLE
go-2769: update graphql queries for db change

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -128,18 +128,19 @@ document.observe('dom:loaded', async function () {
     return result.data?.hpo
   }
 
-  const getFamilyCohortData = async function (phenopacketId) {
-    const getFamily = async function (phenopacketId) {
-      const variables = {
-        phenopacket_id: phenopacketId
-      };
-      const result = await graphql({query: Queries.GET_FAMILY_DATA_FOR_OPEN_PEDIGREE, variables});
-
-      if (result?.data?.family) {
-        return result.data.family;
-      }
-      throw "Error retrieving or creating family object.";
+  const getFamily = async function (phenopacketId) {
+    const variables = {
+      phenopacket_id: phenopacketId
     };
+    const result = await graphql({query: Queries.GET_FAMILY_DATA_FOR_OPEN_PEDIGREE, variables});
+
+    if (result?.data?.family) {
+      return result.data.family;
+    }
+    throw "Error retrieving or creating family object.";
+  };
+
+  const getFamilyCohortData = async function (phenopacketId) {
     const createCohort = async function (individualId, clinicalFamilyRecordIdentifier) {
       const variables = {
         individual_id: individualId,
@@ -233,9 +234,11 @@ document.observe('dom:loaded', async function () {
         }
       },
       save: async ({ jsonData, svgData, setSaveInProgress }) => {
+        const family = await getFamily(urlParams.get('phenopacket_id'));
+
         //setSaveInProgress(true);
         const variables = {
-          phenopacketId: urlParams.get('phenopacket_id'),
+          familyId: family.id,
           rawData: {
             svgData,
             jsonData,

--- a/src/app.js
+++ b/src/app.js
@@ -225,9 +225,7 @@ document.observe('dom:loaded', async function () {
           });
 
           return onSuccess(
-            JSON.stringify(
-              result?.data?.pedigree[0]?.rawData?.jsonData ?? null
-            )
+            result?.data?.pedigree[0]?.rawData?.jsonData ?? null
           );
         } else {
           console.warn('No phenopacket ID has been specified. No data will be saved.')

--- a/src/app.queries.js
+++ b/src/app.queries.js
@@ -146,7 +146,7 @@ export const GET_OPEN_PEDIGREE_DATA = `
   query GetOpenPedigreeData($phenopacketId: uuid!) {
     pedigree:family(where: {phenopacket_id: {_eq: $phenopacketId}}) {
       id
-      rawData: combined_pedigree
+      rawData: pedigree
     }
   }
 `;
@@ -156,13 +156,13 @@ export const UPDATE_OPEN_PEDIGREE_DATA = `
     $familyId: uuid!,
     $rawData: jsonb!
   ) {
-    insert_family_pedigree_one(
-      object: {
+    insert_family_pedigree(
+      objects: {
         family_id: $familyId,
         data: $rawData
       }
     ) {
-      id
+      affected_rows
     }
   }
 `;

--- a/src/app.queries.js
+++ b/src/app.queries.js
@@ -144,26 +144,22 @@ export const REMOVE_COHORT_MEMBER_FROM_OPEN_PEDIGREE = `
 
 export const GET_OPEN_PEDIGREE_DATA = `
   query GetOpenPedigreeData($phenopacketId: uuid!) {
-    pedigree:open_pedigree_data(where: {phenopacket_id: {_eq: $phenopacketId}}) {
+    pedigree:family(where: {phenopacket_id: {_eq: $phenopacketId}}) {
       id
-      rawData: pedigree_data
+      rawData: combined_pedigree
     }
   }
 `;
 
 export const UPDATE_OPEN_PEDIGREE_DATA = `
   mutation UpdateOpenPedigreeData(
-    $phenopacketId: uuid!,
+    $familyId: uuid!,
     $rawData: jsonb!
   ) {
-    insert_family_one(
+    insert_family_pedigree_one(
       object: {
-        phenopacket_id: $phenopacketId,
-        raw_open_pedigree_data: $rawData
-      },
-      on_conflict: {
-        constraint: family_phenopacket_id_key,
-        update_columns: raw_open_pedigree_data
+        family_id: $familyId,
+        data: $rawData
       }
     ) {
       id


### PR DESCRIPTION
Update the read/write queries for saving/loading pedigree data from the Gen-o database to allow new db updates to be utilised.