### PR TITLE
Gh-779: change wording for currently selected highlighted attribute

### DIFF
--- a/src/script/pedigree.js
+++ b/src/script/pedigree.js
@@ -203,7 +203,7 @@ var PedigreeEditor = Class.create({
      */
   updateSwitchColorButtonLabel: function() {
     var switchColorButton = $('action-switch-coloring');
-    switchColorButton.children[1].innerText = `Switch coloring (Now ${this.coloringSource})`;
+    switchColorButton.children[1].innerText = `Shaded by ${this.coloringSource} (click to change)`;
   },
 
   /**


### PR DESCRIPTION
Update text used to change the attribute that pedigrees are shaded by, as there was some comfusion in relation to what the previous wording had meant.