### PR TITLE
gh-737: add val for 0 children in dynamicgraph.js

### DIFF
--- a/src/script/model/dynamicGraph.js
+++ b/src/script/model/dynamicGraph.js
@@ -2082,7 +2082,18 @@ Heuristics.prototype = {
     var children = this.DG.GG.getOutEdges(childhubId);
 
     if (!children || children.length == 0) {
-      return;
+      return {
+        'leftMostHasLPartner': false,
+        'leftMostChildId': undefined,
+        'leftMostChildOrder': Infinity,
+        'rightMostHasRPartner': false,
+        'rightMostChildId': undefined,
+        'rightMostChildOrder': -Infinity,
+        'withPartnerSet': {},
+        'numWithPartners': 0,
+        'numWithTwoPartners': 0,
+        'orderedChildren': []
+      };
     }
 
     var havePartners        = {};


### PR DESCRIPTION
Update `dynamicGraph.js` to provide a returned value if there are no children, as this seems to be where the error occurs - it had used just `return;`, which would come up as an undefined value.

Given this information, it may be a possible cause of gh-688.  This has been noted in the ticket, and will be tested.