### PR TITLE
gh-1125: fix pedigree loading query

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -229,12 +229,12 @@ document.observe('dom:loaded', async function () {
                 variables
               });
 
-              if (!result?.data?.pedigree[0]?.rawData?.jsonData) {
+              if (!result?.data?.family[0]?.rawData?.jsonData) {
                 return onFailure();
               }
 
               return onSuccess(
-                result.data.pedigree[0].rawData.jsonData
+                result.data.family[0].rawData.jsonData
               );
             } else {
               console.warn('No phenopacket ID has been specified. No data will be saved.')

--- a/src/app.queries.js
+++ b/src/app.queries.js
@@ -145,9 +145,9 @@ export const REMOVE_COHORT_MEMBER_FROM_OPEN_PEDIGREE = `
 // ?? should run pedigree_data
 export const GET_OPEN_PEDIGREE_DATA = `
   query GetOpenPedigreeData($phenopacketId: uuid!) {
-    pedigree:family_by_phenopacket_id(args: { get_phenopacket_id: $phenopacketId }) {
+    family(where: {phenopacket_id: {_eq: $phenopacketId}}) {
       id
-      rawData: pedigree
+      rawData:pedigree
     }
   }
 `;


### PR DESCRIPTION
Update the openpedigree loading query to fetch the pedigree specifically by the phenopacket_id and remove related pedigrees as this causes loading issues.