### PR TITLE
gh-1167: export ped <n> nodes as separate entities for canrisk

### DIFF
--- a/src/script/model/export.js
+++ b/src/script/model/export.js
@@ -258,7 +258,14 @@ PedigreeExport.exportAsCanrisk = function(pedigree, idGenerationPreference) {
       ? dobData.getFullYear()
       : 0;
     
-    output += generateLine(individual);
+    const numPersons = parseInt(pedigree.GG.properties[i]['numPersons']) || 1;
+    for (let j = 0; j < numPersons; j++) {
+      let clonedIndividual = { ...individual };
+      if (numPersons > 1) {
+        clonedIndividual.id = individual.id + '_' + (j + 1);
+      }
+      output += generateLine(clonedIndividual);
+    }
   }
 
   return output;


### PR DESCRIPTION
Update the exportAsCanrisk function to check if an <n> node is used to denote multiple individuals.  If it is, clone those individuals in to separate child nodes within the CanRisk export.